### PR TITLE
fix(admin): fix redeploy alert mobile formatting

### DIFF
--- a/app/views/invitation_mailer/send_redeploy_alert.html.erb
+++ b/app/views/invitation_mailer/send_redeploy_alert.html.erb
@@ -53,15 +53,5 @@
       </tr>
     </table>
 
-
-
-    <hr />
-    <a href="http://bit.ly/CCUPod" target="_blank"><img src="http://www.aarontitus.net/crisiscleanup/CCU_Two_Pins_75x75.png" height="75" alt="Crisis Cleanup Podcast" align="left" border="0"></a> Listen to the <em><a href="http://bit.ly/CCUPod" target="_blank">Crisis Cleanup Podcast</a></em>: Just-in-time training and thoughtful conversation about voluntary disaster relief. Also, consider supporting Crisis Cleanup with a small <a href="http://bit.ly/CCUPatreon" target="_blank">monthly donation</a>. We support a new disaster <em>every two weeks</em>, for the last seven years.</p>
-<!--
-    <p><a href="http://h2prep.me/emailfooter" target="_blank"><img src="http://aarontitus.net/crisiscleanup/h2prep_logo.jpg" height="75" alt="How to Prepare for Everything" align="left" border="0"></a> Hey, down here! Disaster relief volunteers receive 20% off <a href="http://h2prep.me/emailfooter" target="_blank"><em>How to Prepare for Everything</em></a>. Prepare with one simple change: Prepare for <em>disruptions</em>, not disasters. It doesn't matter what caused the power outage, just prepare for the power outage! Preparing for a few disruptions will prepare you for any disaster. Use coupon code, <u>volunteer17</u>.</p>
-    <p><strong>Prepare for disruptions.<br />
-    Prepare together.<br />
-    Prepare for everything.</strong></p>
--->
   </body>
 </html>

--- a/app/views/invitation_mailer/send_redeploy_alert.html.erb
+++ b/app/views/invitation_mailer/send_redeploy_alert.html.erb
@@ -47,11 +47,16 @@
         <th width="200" align="left">Previous Events:</th>
         <td><%= @previous_events.join(', ') %></td>
       </tr>
-      <tr class="spaced">
-        <td width="200" align="center"><a <%= "href=\"mailto:#{@user.email}\"".html_safe %>>Reject</a></td>
-        <td width="200" align="left"><%= @redeploy_request.accept  %></td>
-      </tr>
     </table>
+
+
+    <br />
+    <br />
+    <a <%= "href=\"mailto:#{@user.email}\"".html_safe %>>Reject</a>
+    <br />
+    <br />
+    <%= @redeploy_request.accept  %>
+
 
   </body>
 </html>

--- a/app/views/invitation_mailer/send_redeploy_alert.html.erb
+++ b/app/views/invitation_mailer/send_redeploy_alert.html.erb
@@ -2,19 +2,6 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-
-    <style type="text/css">
-      .spaced {
-        display: inline-block;
-        margin-top:30px;
-        margin-left: 50%
-      }
-
-      .spaced > td > a {
-        padding-left: 30px
-      }
-    </style>
-
   </head>
   <body>
 


### PR DESCRIPTION
**Changes**

Admin redeploy alert had some formatting issues on iOS mobile. 

* Removed footer (since only sent to admins)
* Moved accept/reject link out of table