### PR TITLE
feat: Add Confirmation Page with Configuration to Redeploy Request

### DIFF
--- a/app/controllers/worker/redeploy_request_controller.rb
+++ b/app/controllers/worker/redeploy_request_controller.rb
@@ -69,9 +69,11 @@ module Worker
       org.save!
       user = redeploy_request.user
       redeploy_request.save!
-      InvitationMailer.send_redeploy_acceptance(redeploy_request, user.email, current_user).deliver_now
+      email_from = params[:from]
+      email_body = params[:body]
+      InvitationMailer.send_redeploy_acceptance(user.email, email_from, email_body, current_user.email).deliver_now
       org.legacy_contacts.each do |contact|
-        InvitationMailer.send_redeploy_acceptance(redeploy_request, contact.email, current_user).deliver_now
+        InvitationMailer.send_redeploy_acceptance(contact.email, email_from, email_body).deliver_now
       end
       flash[:notice] = "You accepted #{org.name}'s request to redeploy to #{event.name}."
       redirect_to '/dashboard'

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -36,12 +36,9 @@ class InvitationMailer < ActionMailer::Base
     mail(to: email, subject: "New Redeploy Request")
   end
 
-  def send_redeploy_acceptance(redeploy_request, email, accepter)
-    @redeploy_request = redeploy_request
-    @org = redeploy_request.legacy_organization
-    @event = redeploy_request.legacy_event
-    @verified_by = accepter
-    mail(to: email, subject: "Redeploy Request Accepted")
+  def send_redeploy_acceptance(email, from, body, bcc)
+    @message = body
+    mail(to: email, from: from, subject: "Redeploy Request Accepted", bcc: bcc)
   end
 
   def send_registration_confirmation(email, org)

--- a/app/models/redeploy_request.rb
+++ b/app/models/redeploy_request.rb
@@ -26,14 +26,25 @@ class RedeployRequest < ActiveRecord::Base
     end
   end
 
+  def confirm_url
+    return "https://www.crisiscleanup.org/redeploy_request/confirm?token=#{self.token}"
+  end
+
   def accept_url
     return "https://www.crisiscleanup.org/redeploy_request/accept?token=#{self.token}"
   end
 
-
   def accept
-    return "<a href='#{self.accept_url}'>Approve</a>".html_safe
+    return "<a href='#{self.confirm_url}'>Approve</a>".html_safe
   end
+
+  def accept_message(accepter)
+    @org = self.legacy_organization
+    @event = self.legacy_event
+    @verified_by = accepter
+    return "<p>#{@org.name},</p><p>Congratulations! #{@verified_by.name} (#{@verified_by.email}) from #{@verified_by.legacy_organization.name} has reviewed and accepted your request to redeploy to the <strong>#{@event.name}</strong> incident. <br/><br/> Thank you for your contributions!</p>"
+  end
+
 
   protected
   def generate_token

--- a/app/views/invitation_mailer/send_redeploy_acceptance.html.erb
+++ b/app/views/invitation_mailer/send_redeploy_acceptance.html.erb
@@ -4,8 +4,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <p><%= @org.name %>,</p>
-    <p>Congratulations! <%= @verified_by.name %> (<%= @verified_by.email %>) from <%= @verified_by.legacy_organization.name %> has reviewed and accepted your request to redeploy to the <strong><%= @event.name %></strong> incident. <br/><br/> Thank you for your contributions!</p>
+    <%= @message.html_safe %>
     <br />
     <p><strong>-Crisis Cleanup Support Services</strong></p>
     <p>Twitter: <a href="https://twitter.com/CrisisCleanup">@CrisisCleanup</a><br />

--- a/app/views/worker/redeploy_request/_confirm_form.html.erb
+++ b/app/views/worker/redeploy_request/_confirm_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_tag('/redeploy_request/accept', method: "post") do |f| %>
+
+<div class="margin-top row">
+  <div class="medium-10 columns">
+    <label>From Email:</label>
+    <%= text_field_tag(:from, "help@crisiscleanup.org") %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="medium-10 columns">
+    <label>Message Preview:</label>
+  		<%= text_area_tag :body, @message.html_safe, :class => "tinymce", :rows => 10, :cols => 20 %>
+  </div>
+</div>
+
+
+<div class="row">
+  <div class="medium-6 columns">
+    <%= submit_tag("Send", class: "button") %>
+  </div>
+</div>
+<%= hidden_field_tag :token, @token %>
+<%= tinymce %>
+
+<% end %>

--- a/app/views/worker/redeploy_request/index.html.erb
+++ b/app/views/worker/redeploy_request/index.html.erb
@@ -1,0 +1,67 @@
+<% content_for :title do %>
+    Crisis Cleanup - Confirm Redeploy
+<% end %>
+
+<% content_for :subheader do %>
+    <div class="row">
+      <h2 class="center">Confirm Redeploy Request</h2>
+    </div>
+<% end %>
+
+<% content_for :main do %>
+
+<style>
+
+.redeploy-table {
+  margin-left: auto;
+  margin-right: auto
+}
+
+</style>
+
+<div class="row">
+
+
+  <div class="large-7 medium-7 columns">
+    <div class="panel" id="confirm-panel">
+      <h5 class="center">Confirm Redeploy for <%= @org.name %></h5>
+      <%= render 'confirm_form' %>
+    </div>
+  </div>
+
+
+  <div class="large-5 medium-5 columns">
+    <div class="panel" id="info-panel">
+      <h5 class="center">Redeploy Request</h5>
+        <table class="redeploy-table">
+          <tr>
+            <th width="200" align="left">Organization:</th>
+            <td><%= @user.legacy_organization.name %></td>
+          </tr>
+          <tr>
+            <th width="200" align="left">User:</th>
+            <td><%= @user.name %> (<%= @user.email %>)</td>
+          </tr>
+          <tr>
+            <th width="200" align="left">User Phone #:</th>
+            <td><%= @user.mobile %></td>
+          </tr>
+          <tr>
+            <th width="200" align="left">New Event:</th>
+            <td><%= @event.name %></td>
+          </tr>
+          <tr>
+            <th width="200" align="left">Previous Events:</th>
+            <td><%= @previous_events.join(', ') %></td>
+          </tr>
+          <tr>
+            <th width="200" align="left">Status:</th>
+            <td><strong><%= @redeploy_request.accepted ? 'ACCEPTED' : 'PENDING' %></strong></td>
+          </tr>
+        </table>
+    </div>
+  </div>
+
+</div>
+
+<%end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
     get "/change_call_language" => 'dashboard#change_call_language', as: "phone_dashboard_change_call_language"
     get "/done" => 'dashboard#done', as: "phone_dashboard_done"
   end
-  
+
   namespace :admin do
     resources :dashboard, only: [:index]
     resources :legacy_events do
@@ -61,7 +61,8 @@ Rails.application.routes.draw do
   get "/get-started" => 'worker/dashboard#get_started', as:"get_started"
   get "/redeploy_form" => 'worker/dashboard#redeploy_form', as: "redeploy_form"
   post "/redeploy_request" => 'worker/redeploy_request#create'
-  get "/redeploy_request/accept" => 'worker/redeploy_request#accept'
+  get "/redeploy_request/confirm" => 'worker/redeploy_request#confirm_redeploy'
+  post "/redeploy_request/accept" => 'worker/redeploy_request#accept'
 
   namespace :worker do
     get "/incident-chooser" => "dashboard#incident_chooser", as: "incident_chooser"
@@ -83,7 +84,7 @@ Rails.application.routes.draw do
       post "/:id/organizations/:org_id" => "legacy_organizations#show", as: "legacy_organization_caller"
       get "/:id/contacts" => "legacy_contacts#index", as: "legacy_contacts"
       get "/:id/contacts/edit" => "legacy_contacts#edit", as: "legacy_contact_edit"
-      post "/:id/contacts/edit" => "legacy_contacts#edit", as: "legacy_contact_update"     
+      post "/:id/contacts/edit" => "legacy_contacts#edit", as: "legacy_contact_update"
       get "/:id/contacts/:contact_id" => "legacy_contacts#show", as: "legacy_contact"
       get "/:id/map" => "legacy_sites#map", as: "legacy_map"
       get "/:id/form" => "legacy_sites#form", as: "legacy_form"


### PR DESCRIPTION
**Changes**

* Clicking 'accept' on redeploy request will now bring you to a new confirmation page
* Confirmation page contains:
   - Redeploy Request information and Status
   - Text box for configuring "from" email
   - WYSIWYG editor for customizing the acceptance email message
* Will now BCC the admin that accepted the request

**Preview: Confirmation Page**

![image](https://user-images.githubusercontent.com/5913808/75954507-78440980-5e79-11ea-9560-73b38dba12b4.png)
